### PR TITLE
Removing mocha from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,9 @@
     "url": "https://github.com/softmantk/perflog.js/issues"
   },
   "homepage": "https://github.com/softmantk/perflog.js#readme",
-  "dependencies": {
-    "mocha": "^7.1.1"
-  },
+  "dependencies": {},
   "devDependencies": {
+    "mocha": "^7.1.1",
     "chai": "^4.2.0"
   }
 }


### PR DESCRIPTION
Previously mocha was set as a dependency, but since its a testing framework it should instead be listed as a dev dependency.